### PR TITLE
🛠 Fix Build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     container:
-      image: node:16-alpine3.15
+      image: node:16-alpine
     steps:
       - uses: actions/checkout@v3
       - name: 🔧 install + build # This project is built using npm and outputs the result to the 'build' folder

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,7 @@ jobs:
   validate-build:
     runs-on: ubuntu-latest
     container:
-      image: node:16-alpine3.15
+      image: node:16-alpine
     steps:
       - uses: actions/checkout@v3
       - name: 🔧 install + build # This project is built using npm and outputs the result to the 'build' folder


### PR DESCRIPTION
After merging in some recent PRs, the GitHub build/deploy workflows seem to have broken due to this known issue: https://github.com/actions/checkout/issues/335.

Hopefully, the fix should be as simple as reverting to the original `node:16-alpine` image specification in all relevant `.github/workflow` files. 