### PR TITLE
Pin Webpack Dependency to v5.73.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,8 @@
     {
       "matchPackageNames": ["webpack"],
       "matchPackagePrefixes": ["webpack-"],
-      "groupName": "Webpack"
+      "groupName": "Webpack",
+      "allowedVersions": "5.73.x"
     },
     {
       "matchManagers": ["dockerfile", "docker-compose"],


### PR DESCRIPTION
Updating Webpack to v5.74.x, [as suggested by renovate](https://github.com/wayfair-incubator/auxeng-docs/pull/40), results in the build failing. Until we can determine the issue, or Webpack issues a package update which resolves the build failure, we should pin the `allowedVersions` of `webpack` to v5.73.x (to reflect the latest-known stable version of Webpack which builds this project successfully) in the renovate config file (`renovate.json`).

Once this PR is accepted and merged, renovate should automatically close https://github.com/wayfair-incubator/auxeng-docs/pull/40.