### PR TITLE
Add missing `oss-template` content

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+
+Please provide a description of the problem.
+
+## Expected Behaviour
+
+Please describe what you expected would happen.
+
+## Actual Behaviour
+
+Please describe what happened instead.
+
+## Affected Version
+
+Please provide the version number where this issue was encountered.
+
+## Steps to Reproduce
+
+1. First step
+1. Second step
+1. etc.
+
+## Checklist
+
+- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/auxeng-docs/blob/main/CONTRIBUTING.md)
+- [ ] I have verified this does not duplicate an existing issue

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a feature for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Problem Statement
+
+Please describe the problem to be addressed by the proposed feature.
+
+## Proposed Solution
+
+Please describe what you envision the solution to this problem would look like.
+
+## Alternatives Considered
+
+Please briefly describe which alternatives, if any, have been considered, including merits of alternate approaches and
+tradeoffs being made.
+
+## Additional Context
+
+Please provide any other information that may be relevant.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description
+
+Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.
+
+Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.
+
+## Type of Change
+
+- [ ] Bug Fix
+- [ ] New Feature
+- [ ] Breaking Change
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Other (please describe)
+
+## Checklist
+
+- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/auxeng-docs/blob/main/CONTRIBUTING.md)
+- [ ] Existing issues have been referenced (where applicable)
+- [ ] I have verified this change is not present in other open pull requests
+- [ ] Functionality is documented
+- [ ] All code style checks pass
+- [ ] New code contribution is covered by automated tests
+- [ ] All new and existing tests pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### TBA
+
+## [0.0.1] - 2022-10-18
+
+### Added
+
+- Gatsby framework with [wayfair.github.io](https://wayfair.github.io) theming
+- Linting and configuration for Renovate, Markdown
+
+### Changed
+
+- Build and dependency fixes, Docker enhancements
+- Cleaned up and improved Goals splash page
+
+[unreleased]: https://github.com/wayfair-incubator/auxeng-docs/compare/v0.0.1...HEAD
+[0.0.1]: https://github.com/wayfair-incubator/auxeng-docs/releases/tag/v0.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# How to Contribute
+
+Thanks for your interest in contributing to Aux Eng Docs! Here are a few general guidelines on contributing and
+reporting bugs that we ask you to review. Following these guidelines helps to communicate that you respect the time of
+the contributors managing and developing this open source project. In return, they should reciprocate that respect in
+addressing your issue, assessing changes, and helping you finalize your pull requests. In that spirit of mutual respect,
+we endeavour to review incoming issues and pull requests within 10 days, and will close any lingering issues or pull
+requests after 60 days of inactivity.
+
+Please note that all of your interactions in the project are subject to our [Code of Conduct](CODE_OF_CONDUCT.md). This
+includes creation of issues or pull requests, commenting on issues or pull requests, and extends to all interactions in
+any real-time space (eg. Slack, Discord, etc).
+
+## Reporting Issues
+
+Before reporting a new issue, please ensure that the issue was not already reported or fixed by searching through our
+[issues list](https://github.com/wayfair-incubator/auxeng-docs/issues).
+
+When creating a new issue, please be sure to include a **title and clear description**, as much relevant information as
+possible, and, if possible, a test case.
+
+**If you discover a security bug, please do not report it through GitHub. Instead, please see security procedures in
+[SECURITY.md](SECURITY.md).**
+
+## Sending Pull Requests
+
+Before sending a new pull request, take a look at existing pull requests and issues to see if the proposed change or fix
+has been discussed in the past, or if the change was already implemented but not yet released.
+
+We expect new pull requests to include tests for any affected behavior, and, as we follow semantic versioning, we may
+reserve breaking changes until the next major version release.
+
+## Other Ways to Contribute
+
+We welcome anyone that wants to contribute to Aux Eng Docs to triage and reply to open issues to help troubleshoot
+and fix existing bugs. Here is what you can do:
+
+- Help ensure that existing issues follows the recommendations from the _[Reporting Issues](#reporting-issues)_ section,
+  providing feedback to the issue's author on what might be missing.
+- Review and update the existing content of our [Wiki](https://github.com/wayfair-incubator/auxeng-docs/wiki) with up-to-date
+  instructions and code samples.
+- Review existing pull requests, and testing patches against real existing applications that use Aux Eng Docs.
+- Write a test, or add a missing test case to an existing test.
+
+Thanks again for your interest on contributing to Aux Eng Docs!
+
+:heart:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,5 @@
+# Maintainers
+
+- [GaryPWhite](https://github.com/GaryPWhite)
+- [lelia](https://github.com/lelia)
+- [jonbiddle](https://github.com/jonbiddle)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A collection of documentation related to how Wayfair Engineering has implemented "[Auxiliary Engineering](https://www.aboutwayfair.com/tech-innovation/what-is-auxiliary-engineering)"
 
+[![Release](https://img.shields.io/github/v/release/wayfair-incubator/auxeng-docs?display_name=tag)](https://github.com/wayfair-incubator/auxeng-docs/releases)
 [![License: BSD 0-Clause](https://img.shields.io/badge/License-BSD%200--Clause-7462E0.svg)](LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-24B8EE.svg)](CODE_OF_CONDUCT.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the
+Aux Eng Docs project.
+
+- [Reporting a Bug](#reporting-a-bug)
+- [Disclosure Policy](#disclosure-policy)
+- [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+The Aux Eng Docs team and community take all security bugs in
+Aux Eng Docs seriously.  Thank you for improving the security of
+Aux Eng Docs. We appreciate your efforts and responsible disclosure and
+will make every effort to acknowledge your contributions.
+
+Report security bugs by emailing `OpenSource@wayfair.com`.
+
+The lead maintainer will acknowledge your email within 48 hours, and will send a
+more detailed response within 48 hours indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+- Confirm the problem and determine the affected versions.
+- Audit code to find any potential similar problems.
+- Prepare fixes for all releases still under maintenance. These fixes will be
+  released as quickly as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.


### PR DESCRIPTION
Fixes #29.

Derives template content from https://github.com/wayfair-incubator/oss-template